### PR TITLE
add installation of pcl_ros to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     python3-pip \
     python3-testresources \
-    gedit
+    gedit \
+    ros-humble-pcl-ros
     
     
 RUN python3 -m pip install --user --upgrade --no-cache-dir --no-warn-script-location pip && \


### PR DESCRIPTION
## 概要

- pcl_rosの依存関係がrosdepで解決されなかったため、apt-getでinstallするように変更しました。

### その他
<!-- レビューアーに確認してもらいたいこと -->

- `apt-get`の一覧に1つだけROS関係が混ざっているのも変なので一旦ドラフトでPRを立てておきます。
https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2_docker/blob/2c560b680cf9248fb464f2a490880f6d003bba07/Dockerfile#L44-L50