### PR TITLE
Fix/gazebo blackout

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@ docker run \
 	-p 8308:8308/udp \
 	-e HOME=/home/ubuntu \
 	-e SHELL=/bin/bash \
+	--privileged \
 	--shm-size=512m \
         --security-opt seccomp=unconfined \
 	--entrypoint '/startup.sh' \

--- a/runLite.sh
+++ b/runLite.sh
@@ -6,6 +6,7 @@ docker run \
     -p 8308:8308/udp \
     -e HOME=/home/ubuntu \
     -e SHELL=/bin/bash \
+    --privileged \
     --shm-size=512m \
     --security-opt seccomp=unconfined \
     --entrypoint '/startup.sh'\


### PR DESCRIPTION
## 概要

- gazeboがブラックスクリーンのまま起動しない問題の解消。

<!--
### なぜこのタスクを行うのか

- 
-->
### やったこと

- `run.sh`と`runLite.sh`に`--privileged \`を追記しました。
<!--
### できるようになること

- 

### できなくなること

- 
-->
### その他
<!-- レビューアーに確認してもらいたいこと -->

- この問題は最新の`tiryoh/ros2-desktop-vnc:humble`を利用して`docker run`すると発生するようです。詳しくは以下のissueを参照ください。
https://github.com/Tiryoh/docker-ros2-desktop-vnc/issues/85
