### PR TITLE
Create build-and-push.yaml

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,27 @@
+name: Build Docker image and push to Docker Hub
+on:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/orange_ros2:latest


### PR DESCRIPTION
## 概要

- Github Actionsが自動的に`docker build`とDocker hubへのイメージのpushを行います。

### なぜこのタスクを行うのか

- ローカル環境での`docker build`の手間を減らす。

### その他
<!-- レビューアーに確認してもらいたいこと -->

- このGithub ActionはPRが立てられると自動的に実行されます。また、PRを立てた後に該当するブランチが更新された場合にもbuildとpushが再実行されるはずです。
- 使い勝手が良いか等、不明な部分が多いのでIGVC2023-dockerには今の所この機能を実装する予定はありません。
