### PR TITLE
fix bug for device connection

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@ docker run \
 	-p 8308:8308/udp \
 	-e HOME=/home/ubuntu \
 	-e SHELL=/bin/bash \
+	--cap-add IPC_OWNER \
 	--shm-size=512m \
 	--security-opt seccomp=unconfined \
 	--entrypoint '/startup.sh' \

--- a/run.sh
+++ b/run.sh
@@ -6,9 +6,8 @@ docker run \
 	-p 8308:8308/udp \
 	-e HOME=/home/ubuntu \
 	-e SHELL=/bin/bash \
-	--privileged \
 	--shm-size=512m \
-        --security-opt seccomp=unconfined \
+	--security-opt seccomp=unconfined \
 	--entrypoint '/startup.sh' \
 	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
 	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \


### PR DESCRIPTION
## 概要

- 下記PRにてrun.shに`--privileged \`を追記していましたが、このことが原因でdockerでの機器接続が上手くいっていなかったため削除しました。
#3 

### できなくなること

- この作業により、run.shで起動されたコンテナではgazeboが起動しない可能性がありますが、実機で走行する際にはgazeboは利用しないと思うので一旦はこの編集内容で適当かと思います。

