### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # orange_ros2_docker
-<img src="https://user-images.githubusercontent.com/84959376/211188830-9464ddf6-5d16-43bf-908e-90e52eda350c.png" width="500px">
+<img src="https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2_docker/assets/88425011/37f5c928-173b-4e74-a9b6-aab8e5493790" width="500px">
 
 orange_ros2:https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2  
 Distribution: ROS2 Humble Hawksbill


### PR DESCRIPTION
## 概要

- README.mdの画像の差し替え。

### なぜこのタスクを行うのか

- 外装製作後の画像の方が見栄えが良いため。

### やったこと

- README.mdの画像の差し替え。
![スクリーンショット 2023-05-18 16 45 21](https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2_docker/assets/88425011/b332f02e-bda3-4039-b232-57ebf498f473)


### できるようになること

- 見栄えが良くなる。
