### PR TITLE
Feature/add web browser

### DIFF
--- a/.github/workflows/build-check-bot.yaml
+++ b/.github/workflows/build-check-bot.yaml
@@ -1,10 +1,11 @@
-name: Build Docker image and push to Docker Hub
+name: Build Check Bot
 on:
   pull_request:
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,5 +24,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/orange_ros2:latest

--- a/.github/workflows/deploy-bot.yaml
+++ b/.github/workflows/deploy-bot.yaml
@@ -1,10 +1,15 @@
-name: Build Docker image and push to Docker Hub manually
+name: Deploy Bot
 on:
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN apt-get update && \
         supervisor wget curl gosu git sudo python3-pip tini \
         build-essential vim sudo lsb-release locales \
         bash-completion tzdata terminator && \
+    add-apt-repository ppa:mozillateam/ppa -y && \
+    echo 'Package: firefox*' > /etc/apt/preferences.d/mozillateamppa && \
+    echo 'Pin: release o=LP-PPA-mozillateam' >> /etc/apt/preferences.d/mozillateamppa && \
+    echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mozillateamppa && \
+    apt-get update && \
+    apt-get install -y firefox && \
     apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,41 @@ mkdir -p $HOME/.ros
 cp -r /root/.ros/rosdep $HOME/.ros/rosdep
 chown -R $USER:$USER $HOME/.ros
 
+# Create terminator shortcut
+mkdir -p $HOME/Desktop
+cat << EOF > $HOME/Desktop/terminator.desktop
+[Desktop Entry]
+Name=Terminator
+Comment=Multiple terminals in one window
+TryExec=terminator
+Exec=terminator
+Icon=terminator
+Type=Application
+Categories=GNOME;GTK;Utility;TerminalEmulator;System;
+StartupNotify=true
+X-Ubuntu-Gettext-Domain=terminator
+X-Ayatana-Desktop-Shortcuts=NewWindow;
+Keywords=terminal;shell;prompt;command;commandline;
+[NewWindow Shortcut Group]
+Name=Open a New Window
+Exec=terminator
+TargetEnvironment=Unity
+EOF
+
+# Create firefox shortcut
+cat << EOF > $HOME/Desktop/firefox.desktop
+[Desktop Entry]
+Name=Firefox Web Browser
+Comment=Browse the World Wide Web
+Exec=firefox
+Icon=firefox
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+Keywords=Internet;WWW;Browser;Web;Explorer
+EOF
+chown -R $USER:$USER $HOME/Desktop
+
 # clearup
 PASSWORD=
 VNC_PASSWORD=

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,5 @@
 docker run \
 	-p 6080:80 \
-	-p 2222:22 \
-	-p 10940:10940 \
-	-p 2368:2368/udp \
-	-p 8308:8308/udp \
 	--shm-size=512m \
 	--security-opt seccomp=unconfined \
 	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \

--- a/runLite.sh
+++ b/runLite.sh
@@ -1,9 +1,5 @@
 docker run \
     -p 6080:80 \
-    -p 2222:22 \
-    -p 10940:10940 \
-    -p 2368:2368/udp \
-    -p 8308:8308/udp \
     --shm-size=512m \
     --security-opt seccomp=unconfined \
     orange_ros2


### PR DESCRIPTION
## 概要

- firefoxの追加。
- firefoxとterminatorのデスクトップへのショートカットの追加。
- `docker run`時の必要でないと思われるportの削除。
- github workflowsの名前変更、タイムアウトの設定、トリガーするイベントの変更。

### なぜこのタスクを行うのか
このPRにおける主なモチベーションは以下です。
- コンテナ内でwebブラウザを利用したい。
- PRを立てた際にはbuildをするのみ(Dockerhubへのpushはしない)で、マージされたときにpushが行われるようにしたい。

### その他
<!-- レビューアーに確認してもらいたいこと -->
このリポジトリにおいてPRとworkflowsとの関係は以下のような流れとなります。
1. PRを作成する。
2. `Build Check Bot`がbuildを実施する(Dockerhubへのpushはしない)。
3. PRにコミットを追加する。
4. `Build Check Bot`がbuildを実施する(Dockerhubへのpushはしない)。
... 以下ループ。
5. レビューが完了しPRが閉じられる。
6. `Deploy Bot`がbuild及びDocker Hubへのpushを行う。