### PR TITLE
Fix/run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,9 @@
 docker run \
 	-p 6080:80 \
+	-p 2222:22 \
+	-p 10940:10940 \
+	-p 2368:2368/udp \
+	-p 8308:8308/udp \
 	--shm-size=512m \
 	--security-opt seccomp=unconfined \
 	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,6 @@ docker run \
 	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
 	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
 	--device /dev/input/js0:/dev/input/js0:mwr \
-	orange_ros2
+	kbkn202x/orange_ros2:latest
 	
 	#-e RESOLUTION=1920x1080

--- a/runLite.sh
+++ b/runLite.sh
@@ -1,5 +1,9 @@
 docker run \
     -p 6080:80 \
+    -p 2222:22 \
+    -p 10940:10940 \
+    -p 2368:2368/udp \
+    -p 8308:8308/udp \
     --shm-size=512m \
     --security-opt seccomp=unconfined \
     orange_ros2

--- a/runLite.sh
+++ b/runLite.sh
@@ -6,6 +6,6 @@ docker run \
     -p 8308:8308/udp \
     --shm-size=512m \
     --security-opt seccomp=unconfined \
-    orange_ros2
+    kbkn202x/orange_ros2:latest
     
     #-e RESOLUTION=1920x1080 \


### PR DESCRIPTION
## 概要

- 以下のコミットにおいて生じたvelodyne利用不可バグの修正。
- https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2_docker/commit/7ca23b270f735dd1330a3920b7f8f0edde951c32

### なぜこのタスクを行うのか

- 実機でvelodyneが利用不可能になっていたため。

### やったこと

- run.sh、runLite.shの修正

### できるようになること

- 実環境でのvelodyne利用
