### PR TITLE
Update Dockerfile cm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build"
 
 # Update .bashrc with custom aliases
 RUN echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc && \
-    echo "alias cm='cd ~/ros2_ws;colcon build'" >> ~/.bashrc && \
+    echo "alias cm='cd ~/ros2_ws;colcon build;source ~/.bashrc'" >> ~/.bashrc && \
     echo "alias cs='cd ~/ros2_ws/src'" >> ~/.bashrc && \
     echo "alias cw='cd ~/ros2_ws'" >> ~/.bashrc
 


### PR DESCRIPTION
## 概要

- Dockerfile内のcmへの追記.

### なぜこのタスクを行うのか

- Dockerfile内のcmコマンドのみでcolcon buildに加えてsource ~/.bashrcも行うため. 

### やったこと

- Dockerfile内のecho "alias cm='cd ~/ros2_ws;colcon build'" >> ~/.bashrc && \へのsource ~/.bashrcの追記.

### できるようになること

- cmコマンドのみでのcolcon buildおよびsource.
