### PR TITLE
Add estop in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,11 @@ docker run \
 	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
 	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
 	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
+        --device /dev/sensors/estop:/dev/sensors/estop:mwr \
 	--device /dev/input/js0:/dev/input/js0:mwr \
+        --device /dev/input/js1:/dev/input/js1:mwr \
 	kbkn202x/orange_ros2:latest
 	
 	#-e RESOLUTION=1920x1080
+ #js0;DualSense Controller
+ #js1;DualSense trackpad


### PR DESCRIPTION
## 概要

- run.shへのestopの追加.

### なぜこのタスクを行うのか

- estopを実機で利用するため.

### やったこと

- run.sh内にestopを追加.

### できるようになること

- 実機でのestop利用.
