### PR TITLE
add map_merger alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc && \
     echo "alias cm='cd ~/ros2_ws;colcon build;source ~/.bashrc'" >> ~/.bashrc && \
     echo "alias cs='cd ~/ros2_ws/src'" >> ~/.bashrc && \
     echo "alias cw='cd ~/ros2_ws'" >> ~/.bashrc && \
-    echo "alias waypoint_manager='python3 /home/ubuntu/ros2_ws/src/orange_navigation/waypoint_manager/manager_GUI.py'" >> ~/.bashrc
+    echo "alias waypoint_manager='python3 /home/ubuntu/ros2_ws/src/orange_navigation/waypoint_manager/manager_GUI.py'" >> ~/.bashrc && \
     echo "alias map_merger='python3 /home/ubuntu/ros2_ws/src/multi_map_manager/map_merger.py'" >> ~/.bashrc
 
 # Switch back to 'root' user

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ RUN echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc && \
     echo "alias cs='cd ~/ros2_ws/src'" >> ~/.bashrc && \
     echo "alias cw='cd ~/ros2_ws'" >> ~/.bashrc && \
     echo "alias waypoint_manager='python3 /home/ubuntu/ros2_ws/src/orange_navigation/waypoint_manager/manager_GUI.py'" >> ~/.bashrc
+    echo "alias map_merger='python3 /home/ubuntu/ros2_ws/src/multi_map_manager/map_merger.py'" >> ~/.bashrc
 
 # Switch back to 'root' user
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,8 @@ RUN echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc && \
     echo "alias cs='cd ~/ros2_ws/src'" >> ~/.bashrc && \
     echo "alias cw='cd ~/ros2_ws'" >> ~/.bashrc && \
     echo "alias waypoint_manager='python3 /home/ubuntu/ros2_ws/src/orange_navigation/waypoint_manager/manager_GUI.py'" >> ~/.bashrc && \
-    echo "alias map_merger='python3 /home/ubuntu/ros2_ws/src/multi_map_manager/map_merger.py'" >> ~/.bashrc
+    echo "alias map_merger='python3 /home/ubuntu/ros2_ws/src/multi_map_manager/map_merger/map_merger.py'" >> ~/.bashrc && \
+    echo "alias map_trimmer='python3 /home/ubuntu/ros2_ws/src/multi_map_manager/map_merger/map_trimmer.py'" >> ~/.bashrc
 
 # Switch back to 'root' user
 USER root


### PR DESCRIPTION
## 概要

- map_mergerのaliasへの追加. 

### なぜこのタスクを行うのか

- 使用頻度の高いmap_mergerを素早く利用するため. 

### やったこと

- Dockerfile内のalias記述部分への追記. 

### できるようになること

- map_mergerと入力するだけでmap_maegerが立ち上がり, 利用できる. 
