### PR TITLE
add_gimp_in_Install_Ubuntu_Mate_desktop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN apt-get update && \
     mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg && \
     sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list' && \
     apt-get update && \
-    apt-get install -y firefox code && \
-    apt-get install gimp && \
+    apt-get install -y firefox code gimp && \
     apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -q && \
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ubuntu-mate-desktop && \
+    gimp && \
     apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -q && \
 # Install Ubuntu Mate desktop
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ubuntu-mate-desktop && \
+    ubuntu-mate-desktop \
     gimp && \
     apt-get autoclean && \
     apt-get autoremove && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update -q && \
 # Install Ubuntu Mate desktop
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ubuntu-mate-desktop \
-    gimp && \
+    ubuntu-mate-desktop && \
     apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -37,6 +36,7 @@ RUN apt-get update && \
     sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list' && \
     apt-get update && \
     apt-get install -y firefox code && \
+    apt-get install gimp && \
     apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,6 +126,20 @@ Name=New Empty Window
 Exec=/usr/share/code/code --new-window %F
 Icon=vscode
 EOF
+
+# Create gimp shortcut
+cat << EOF > $HOME/Desktop/gimp.desktop
+[Desktop Entry]
+Name=GNU Image Manipulation Program
+Comment=Image editing and manipulation program
+Exec=gimp
+Icon=gimp
+Terminal=false
+Type=Application
+Categories=Graphics;ImageEditing;
+Keywords=Image;Editing;GIMP;
+EOF
+
 chown -R $USER:$USER $HOME/Desktop
 
 # clearup


### PR DESCRIPTION
## 概要

- 画像編集ソフト(gimp)インストールの自動化. 

### なぜこのタスクを行うのか

- 現在, 環境地図のクリーンアップにgimpを使用しているが, 使用前にWiFi環境下でインストールする必要があり手間だから. 
- 特に屋外での作業時に不便だと感じた. 

### やったこと

- Dockerfile内のInstall Ubuntu Mate desktop内にgimpを追記した. 

### できるようになること

- dockerからイメージを入れた時点でインストール作業なくgimpを利用できるようになる. 

### できなくなること

- なし. 
