### PR TITLE
Feature/  net=host

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,9 +43,9 @@ cat << EOF > $VNCRUN_PATH
 #!/bin/sh
 
 if [ $(uname -m) = "aarch64" ]; then
-    LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :1 -fg -geometry 1920x1080 -depth 24
+    LD_PRELOAD=/lib/aarch64-linux-gnu/libgcc_s.so.1 vncserver :5 -geometry 1920x1080 -depth 24
 else
-    vncserver :1 -fg -geometry 1920x1080 -depth 24
+    vncserver :5 -geometry 1920x1080 -depth 24 -fg
 fi
 EOF
 
@@ -58,7 +58,7 @@ user=root
 [program:vnc]
 command=gosu '$USER' bash '$VNCRUN_PATH'
 [program:novnc]
-command=gosu '$USER' bash -c "websockify --web=/usr/lib/novnc 80 localhost:5901"
+command=gosu '$USER' bash -c "websockify --web=/usr/lib/novnc 6080 localhost:5905"
 EOF
 
 # colcon

--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,0 +1,28 @@
+sudo docker run \
+    --privileged -it \
+    -p 6080:80 \
+    -p 2222:22 \
+    -p 10940:10940 \
+    -p 2368:2368/udp \
+    -p 8308:8308/udp \
+    -p 56000:56000/udp \
+    --ipc host \
+    --net host \
+    --shm-size=512m \
+    --security-opt seccomp=unconfined \
+    --device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
+    --device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
+    --device /dev/sensors/estop:/dev/sensors/estop:mwr \
+    --device /dev/input/js0:/dev/input/js0:mwr \
+    kbkn202x/orange_ros2:latest
+	
+#-e RESOLUTION=1920x1080
+ #js0;DualSense Controller
+ #js1;DualSense trackpad
+ #--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
+ #	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
+ #	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
+ #      --device /dev/sensors/estop:/dev/sensors/estop:mwr \
+ #	--device /dev/input/js0:/dev/input/js0:mwr \
+ #      --device /dev/input/js1:/dev/input/js1:mwr \
+ #	--device /dev/ttyUSB0:/dev/ttyUSB0:mwr \  

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -1,0 +1,16 @@
+sudo docker run \
+    --privileged -it \
+    -p 6080:80 \
+    -p 2222:22 \
+    -p 10940:10940 \
+    -p 2368:2368/udp \
+    -p 8308:8308/udp \
+    -p 56000:56000/udp \
+    --ipc host \
+    --net host \
+    --shm-size=512m \
+    --security-opt seccomp=unconfined \
+    kbkn202x/orange_ros2:latest
+    
+    #-e RESOLUTION=1920x1080 \
+

--- a/run.sh
+++ b/run.sh
@@ -9,10 +9,10 @@ docker run \
 	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
 	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
 	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
-        --device /dev/sensors/estop:/dev/sensors/estop:mwr \
+	--device /dev/sensors/estop:/dev/sensors/estop:mwr \
 	--device /dev/input/js0:/dev/input/js0:mwr \
-        --device /dev/input/js1:/dev/input/js1:mwr \
-	kbkn202x/orange_ros2:latest
+	--device /dev/input/js1:/dev/input/js1:mwr \
+ 	kbkn202x/orange_ros2:latest
 	
 	#-e RESOLUTION=1920x1080
  #js0;DualSense Controller

--- a/velodyne.sh
+++ b/velodyne.sh
@@ -1,6 +1,6 @@
 while true
 do
-    sudo ifconfig enp3s0 192.168.1.1
+    sudo ifconfig enp3s0 192.168.3.1
     sudo route add -host 192.168.3.11 gw 192.168.3.1 enp3s0
     sudo route add -host 192.168.3.201 gw 192.168.3.1 enp3s0
     

--- a/velodyne.sh
+++ b/velodyne.sh
@@ -1,6 +1,6 @@
 while true
 do
-    sudo ifconfig enp3s0 192.168.3.1
+    sudo ifconfig enp3s0 192.168.1.1
     sudo route add -host 192.168.3.11 gw 192.168.3.1 enp3s0
     sudo route add -host 192.168.3.201 gw 192.168.3.1 enp3s0
     


### PR DESCRIPTION
## 概要
・docker run 時の --net=host オプションの追加

### なぜこのタスクを行うのか
・Livox-Mid360のコンテナ内有効化のため

### やったこと
・entrypoint.shの46,48.61行目の変更
・livox_runLite.sh、livox_run.shの追加（runLite.sh、run.shに--net=hostオプションに必要なものを追記）

### できるようになること
・dockerコンテナを--net=hostオプションを用いて作成可能になる

### できなくなること

### その他
<!-- レビューアーに確認してもらいたいこと -->
