### PR TITLE
Fix/file name

### DIFF
--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,11 +1,5 @@
 sudo docker run \
     --privileged -it \
-    -p 6080:80 \
-    -p 2222:22 \
-    -p 10940:10940 \
-    -p 2368:2368/udp \
-    -p 8308:8308/udp \
-    -p 56000:56000/udp \
     --ipc host \
     --net host \
     --shm-size=512m \
@@ -19,5 +13,11 @@ sudo docker run \
 #   -e RESOLUTION=1920x1080
 #   js0;DualSense Controller
 #   js1;DualSense trackpad
+#   -p 6080:80
+#   -p 2222:22
+#   -p 10940:10940
+#   -p 2368:2368/udp
+#   -p 8308:8308/udp
+#   -p 56000:56000/udp
 #	--device /dev/sensors/imu:/dev/sensors/imu:mwr
 #	--device /dev/ttyUSB0:/dev/ttyUSB0:mwr

--- a/livox_run.sh
+++ b/livox_run.sh
@@ -16,13 +16,8 @@ sudo docker run \
     --device /dev/input/js0:/dev/input/js0:mwr \
     kbkn202x/orange_ros2:latest
 	
-#-e RESOLUTION=1920x1080
- #js0;DualSense Controller
- #js1;DualSense trackpad
- #--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
- #	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
- #	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
- #      --device /dev/sensors/estop:/dev/sensors/estop:mwr \
- #	--device /dev/input/js0:/dev/input/js0:mwr \
- #      --device /dev/input/js1:/dev/input/js1:mwr \
- #	--device /dev/ttyUSB0:/dev/ttyUSB0:mwr \  
+#   -e RESOLUTION=1920x1080
+#   js0;DualSense Controller
+#   js1;DualSense trackpad
+#	--device /dev/sensors/imu:/dev/sensors/imu:mwr
+#	--device /dev/ttyUSB0:/dev/ttyUSB0:mwr

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -12,5 +12,4 @@ sudo docker run \
     --security-opt seccomp=unconfined \
     kbkn202x/orange_ros2:latest
     
-    #-e RESOLUTION=1920x1080 \
-
+#   -e RESOLUTION=1920x1080

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -1,11 +1,5 @@
 sudo docker run \
     --privileged -it \
-    -p 6080:80 \
-    -p 2222:22 \
-    -p 10940:10940 \
-    -p 2368:2368/udp \
-    -p 8308:8308/udp \
-    -p 56000:56000/udp \
     --ipc host \
     --net host \
     --shm-size=512m \
@@ -13,3 +7,9 @@ sudo docker run \
     kbkn202x/orange_ros2:latest
     
 #   -e RESOLUTION=1920x1080
+#   -p 6080:80
+#   -p 2222:22
+#   -p 10940:10940
+#   -p 2368:2368/udp
+#   -p 8308:8308/udp
+#   -p 56000:56000/udp

--- a/velodyne_run.sh
+++ b/velodyne_run.sh
@@ -14,6 +14,6 @@ docker run \
 	--device /dev/input/js1:/dev/input/js1:mwr \
  	kbkn202x/orange_ros2:latest
 	
-#-e RESOLUTION=1920x1080
-#js0;DualSense Controller
-#js1;DualSense trackpad
+#   -e RESOLUTION=1920x1080
+#   js0;DualSense Controller
+#   js1;DualSense trackpad

--- a/velodyne_run.sh
+++ b/velodyne_run.sh
@@ -14,6 +14,6 @@ docker run \
 	--device /dev/input/js1:/dev/input/js1:mwr \
  	kbkn202x/orange_ros2:latest
 	
-	#-e RESOLUTION=1920x1080
- #js0;DualSense Controller
- #js1;DualSense trackpad
+#-e RESOLUTION=1920x1080
+#js0;DualSense Controller
+#js1;DualSense trackpad

--- a/velodyne_runLite.sh
+++ b/velodyne_runLite.sh
@@ -8,4 +8,4 @@ docker run \
     --security-opt seccomp=unconfined \
     kbkn202x/orange_ros2:latest
     
-    #-e RESOLUTION=1920x1080 \
+#-e RESOLUTION=1920x1080

--- a/velodyne_runLite.sh
+++ b/velodyne_runLite.sh
@@ -8,4 +8,4 @@ docker run \
     --security-opt seccomp=unconfined \
     kbkn202x/orange_ros2:latest
     
-#-e RESOLUTION=1920x1080
+#   -e RESOLUTION=1920x1080


### PR DESCRIPTION
## 概要

- run.shとrunLite.shの名前をvelodyne_run.shとvelodyne_runLite.shに変えました。

### なぜこのタスクを行うのか

- livox用にrun.shとrunLite.shを作ったので、velodyne用との違いをつけるため。

### やったこと

- run.shとrunLite.shの名前をvelodyne_run.shとvelodyne_runLite.shに変えました。
- いらないコメントを消しました。
- ポートを指定するとビルド時にwarningが出るため、コメントアウトしました。

### できるようになること

- livox用とvelodyne用との区別ができるようになります。

### できなくなること

- ポートの指定ができなくなると思います。
- livoxのポートが使えるようになれば、この問題は解決すると思います。

### その他
<!-- レビューアーに確認してもらいたいこと -->

-
