### PR TITLE
fix ./livox_run.sh

### DIFF
--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,5 +1,4 @@
 sudo docker run \
-    --privileged -it \
     --ipc host \
     --net host \
     --shm-size=512m \


### PR DESCRIPTION
## 概要
livox_run.shの修正

### なぜこのタスクを行うのか
コンテナがデバイスの認識を行わない問題があったため。

### やったこと
ファイル内の--privileged-itを削除した。

### できるようになること
livox_run.shで建てたコンテナ内でデバイスを認識できるようになる。

### できなくなること
デバイスをつながない状態でのlivox_run.shによるコンテナの起動
