### PR TITLE
Feature/require container name

### DIFF
--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,4 +1,13 @@
+# Check if the name for a container is provided or not
+if [ -z "$1" ]; then
+    echo "Error: You must specify the container name as the first argument."
+    exit 1
+fi
+
+CONTAINER_NAME=$1
+
 sudo docker run \
+    --name "$CONTAINER_NAME" \
     --ipc host \
     --net host \
     --shm-size=512m \

--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,4 +1,4 @@
-# Check if the name for a container is provided or not
+# Check if a container name is provided or not
 if [ -z "$1" ]; then
     echo "Error: You must specify the container name as the first argument."
     exit 1

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -1,4 +1,13 @@
+# Check if the name for a container is provided or not
+if [ -z "$1" ]; then
+    echo "Error: You must specify the container name as the first argument."
+    exit 1
+fi
+
+CONTAINER_NAME=$1
+
 sudo docker run \
+    --name "$CONTAINER_NAME" \
     --ipc host \
     --net host \
     --shm-size=512m \

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -1,4 +1,4 @@
-# Check if the name for a container is provided or not
+# Check if a name container is provided or not
 if [ -z "$1" ]; then
     echo "Error: You must specify the container name as the first argument."
     exit 1


### PR DESCRIPTION
## 概要

- コンテナ作成時にコンテナ名を付けられる機能を追加した
- 以下のように、コンテナを作成するときに引数として名前を指定できる
```
$  bash livox_run.sh your-container-name
```
### なぜこのタスクを行うのか

- 実機用PCに複数のコンテナがあり、誰がどのコンテナを使っているのか分からない状態であるため

### やったこと

- `livox_run.sh`と`livox_runLite.sh`のシェルスクリプトを編集した

### できるようになること

- これまではメモ帳などでコンテナIDを記録し、誰がどのコンテナで作業しているか管理していたが、コンテナに名前を付けることで、誰のコンテナかを明示的に識別できるようになる

### できなくなること

- 名前の指定なしに新たにコンテナを作成することはできない

### その他
<!-- レビューアーに確認してもらいたいこと -->

- `livox_runLite.sh`でのみ検証しましたが、以下のように名前を指定できることを確認しました

![スクリーンショット 2024-11-11 220519](https://github.com/user-attachments/assets/5246fc35-04b9-4b7d-8111-6536d6b67fcd)
